### PR TITLE
ISSUE#***: Fix notify all form elements in form:block

### DIFF
--- a/tools/form/taglib/FormGroupTag.php
+++ b/tools/form/taglib/FormGroupTag.php
@@ -48,15 +48,14 @@ class FormGroupTag extends AbstractFormControl implements FormElementGroup {
    }
 
    public function isValid() {
+      $result = true;
       foreach ($this->children as &$child) {
          if ($child instanceof FormControl) {
-            if ($child->isValid() === false) {
-               return false;
-            }
+            $result = $child->isValid() && $result;            
          }
       }
 
-      return true;
+      return $result;
    }
 
    public function isSent() {


### PR DESCRIPTION
HAbe den Vilidator des Group tags entsprechend  dem vorbild angepasst so das nach dem ersten false nicht gleich abgebrochen wird sondern weiter gemacht um alle element zu prüfen.